### PR TITLE
Docker image renaming to differentiate from the generic bridge contracts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,10 +22,10 @@ if [ ! -f ./deploy/.env ]; then
   exit 3
 fi
 
-docker-compose images bridge-contracts >/dev/null 2>/dev/null
+docker-compose images nft-omnibridge-contracts >/dev/null 2>/dev/null
 if [ "$?" == "1" ]; then
-  echo "Docker image 'bridge-contracts' not found"
+  echo "Docker image 'nft-omnibridge-contracts' not found"
   exit 2
 fi
 
-docker-compose run bridge-contracts deploy.sh "$@"
+docker-compose run nft-omnibridge-contracts deploy.sh "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.3"
 services:
-  bridge-contracts:
+  nft-omnibridge-contracts:
     build: .
     command: "true"
     env_file: ./deploy/.env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge-nft",
-  "version": "1.0.0",
+  "version": "1.0.0-rc1",
   "description": "Omnibridge NFT AMB extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The docker image name has been changed as so we can differentiate:
- `poanetwork/tokenbridge-contracts` for https://github.com/poanetwork/tokenbridge-contracts
- `poanetwork/omnibridge-contracts` for https://github.com/poanetwork/omnibridge
- `poanetwork/nft-omnibridge-contracts` for https://github.com/poanetwork/omnibridge-nft