### PR TITLE
Convert modules to upgradeable contracts

### DIFF
--- a/contracts/upgradeability/UpgradeabilityOwnerStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityOwnerStorage.sol
@@ -5,21 +5,26 @@ pragma solidity 0.7.5;
  * @dev This contract keeps track of the upgradeability owner
  */
 contract UpgradeabilityOwnerStorage {
-    // Owner of the contract
-    address internal _upgradeabilityOwner;
-
     /**
      * @dev Tells the address of the owner
-     * @return the address of the owner
+     * @return owner the address of the owner
      */
-    function upgradeabilityOwner() public view returns (address) {
-        return _upgradeabilityOwner;
+    function upgradeabilityOwner() public view returns (address owner) {
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1)
+            owner := sload(0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103)
+        }
     }
 
     /**
      * @dev Sets the address of the owner
      */
     function setUpgradeabilityOwner(address newUpgradeabilityOwner) internal {
-        _upgradeabilityOwner = newUpgradeabilityOwner;
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1)
+            sstore(0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103, newUpgradeabilityOwner)
+        }
     }
 }

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -25,22 +25,22 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
     }
 
     /**
-     * @dev Upgrades the implementation address
-     * @param version representing the version name of the new implementation to be set
-     * @param implementation representing the address of the new implementation to be set
+     * @dev Upgrades the implementation address.
+     * @param _version representing the version name of the new implementation to be set.
+     * @param _implementation representing the address of the new implementation to be set.
      */
-    function _upgradeTo(uint256 version, address implementation) internal {
-        require(_implementation != implementation);
+    function _upgradeTo(uint256 _version, address _implementation) internal {
+        require(_implementation != implementation());
 
         // This additional check verifies that provided implementation is at least a contract
-        require(Address.isContract(implementation));
+        require(Address.isContract(_implementation));
 
         // This additional check guarantees that new version will be at least greater than the privios one,
         // so it is impossible to reuse old versions, or use the last version twice
-        require(version > _version);
+        require(_version > version());
 
-        _version = version;
-        _implementation = implementation;
-        emit Upgraded(version, implementation);
+        _setVersion(_version);
+        _setImplementation(_implementation);
+        emit Upgraded(_version, _implementation);
     }
 }

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -5,25 +5,51 @@ pragma solidity 0.7.5;
  * @dev This contract holds all the necessary state variables to support the upgrade functionality
  */
 contract UpgradeabilityStorage {
-    // Version name of the current implementation
-    uint256 internal _version;
-
-    // Address of the current implementation
-    address internal _implementation;
-
     /**
      * @dev Tells the version name of the current implementation
-     * @return uint256 representing the name of the current version
+     * @return version uint256 representing the name of the current version
      */
-    function version() external view returns (uint256) {
-        return _version;
+    function version() public view returns (uint256 version) {
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.version')) - 1)
+            version := sload(0x460994c355dbc8229336897ed9def5884fb6b26b0a995b156780d056c758577d)
+        }
     }
 
     /**
      * @dev Tells the address of the current implementation
-     * @return address of the current implementation
+     * @return impl address of the current implementation
      */
-    function implementation() public view virtual returns (address) {
-        return _implementation;
+    function implementation() public view virtual returns (address impl) {
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+            impl := sload(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc)
+        }
+    }
+
+    /**
+     * Internal function for updating version of the implementation contract.
+     * @param _version new version number.
+     */
+    function _setVersion(uint256 _version) internal {
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.version')) - 1)
+            sstore(0x460994c355dbc8229336897ed9def5884fb6b26b0a995b156780d056c758577d, _version)
+        }
+    }
+
+    /**
+     * Internal function for updating implementation contract address.
+     * @param _impl new implementation contract address.
+     */
+    function _setImplementation(address _impl) internal {
+        assembly {
+            // EIP 1967
+            // bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+            sstore(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc, _impl)
+        }
     }
 }

--- a/contracts/upgradeable_contracts/omnibridge_nft/modules/OmnibridgeModule.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/modules/OmnibridgeModule.sol
@@ -12,14 +12,6 @@ abstract contract OmnibridgeModule is VersionableModule {
     IOwnable public mediator;
 
     /**
-     * @dev Initializes this contract.
-     * @param _mediator address of the Omnibridge mediator contract that is allowed to perform additional actions on the particular module.
-     */
-    constructor(IOwnable _mediator) {
-        mediator = _mediator;
-    }
-
-    /**
      * @dev Throws if sender is not the owner of this contract.
      */
     modifier onlyOwner {

--- a/contracts/upgradeable_contracts/omnibridge_nft/modules/forwarding_rules/NFTForwardingRulesManager.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/modules/forwarding_rules/NFTForwardingRulesManager.sol
@@ -15,8 +15,15 @@ contract NFTForwardingRulesManager is OmnibridgeModule {
 
     event ForwardingRuleUpdated(address token, address sender, address receiver, int256 lane);
 
-    // solhint-disable-next-line no-empty-blocks
-    constructor(IOwnable _mediator) OmnibridgeModule(_mediator) {}
+    /**
+     * @dev Initializes this module contract. Intended to be called only once through the proxy pattern.
+     * @param _mediator address of the Omnibridge contract working with this module.
+     */
+    function initialize(IOwnable _mediator) external {
+        require(address(mediator) == address(0));
+
+        mediator = _mediator;
+    }
 
     /**
      * @dev Tells the module interface version that this contract supports.

--- a/contracts/upgradeable_contracts/omnibridge_nft/modules/gas_limit/SelectorTokenGasLimitManager.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/modules/gas_limit/SelectorTokenGasLimitManager.sol
@@ -9,18 +9,27 @@ import "../OmnibridgeModule.sol";
  * @dev Multi NFT mediator functionality for managing request gas limits.
  */
 contract SelectorTokenGasLimitManager is OmnibridgeModule {
-    IAMB public immutable bridge;
+    IAMB public bridge;
 
     uint256 internal defaultGasLimit;
     mapping(bytes4 => uint256) internal selectorGasLimit;
     mapping(bytes4 => mapping(address => uint256)) internal selectorTokenGasLimit;
 
-    constructor(
+    /**
+     * @dev Initializes this module contract. Intended to be called only once through the proxy pattern.
+     * @param _bridge address of the AMB bridge contract to which Omnibridge mediator is connected.
+     * @param _mediator address of the Omnibridge contract working with this module.
+     * @param _gasLimit default gas limit for the message execution.
+     */
+    function initialize(
         IAMB _bridge,
         IOwnable _mediator,
         uint256 _gasLimit
-    ) OmnibridgeModule(_mediator) {
+    ) external {
+        require(address(mediator) == address(0));
+
         require(_gasLimit <= _bridge.maxGasPerTx());
+        mediator = _mediator;
         bridge = _bridge;
         defaultGasLimit = _gasLimit;
     }

--- a/deploy/src/deploymentUtils.js
+++ b/deploy/src/deploymentUtils.js
@@ -135,6 +135,14 @@ async function upgradeProxy({ proxy, implementationAddress, version, nonce, netw
   })
 }
 
+async function upgradeProxyAndCall({ proxy, implementationAddress, version, data, nonce, network }) {
+  await sendTx(network, {
+    data: proxy.methods.upgradeToAndCall(version, implementationAddress, data).encodeABI(),
+    nonce,
+    to: proxy.options.address,
+  })
+}
+
 async function transferProxyOwnership({ proxy, newOwner, nonce, network }) {
   await sendTx(network, {
     data: proxy.methods.transferProxyOwnership(newOwner).encodeABI(),
@@ -169,6 +177,7 @@ module.exports = {
   sendRawTxHome,
   sendRawTxForeign,
   upgradeProxy,
+  upgradeProxyAndCall,
   transferProxyOwnership,
   transferOwnership,
   setBridgeContract,

--- a/deploy/src/loadContracts.js
+++ b/deploy/src/loadContracts.js
@@ -1,5 +1,6 @@
 module.exports = {
   EternalStorageProxy: require(`../../build/contracts/EternalStorageProxy.json`),
+  OwnedUpgradeabilityProxy: require(`../../build/contracts/OwnedUpgradeabilityProxy.json`),
   HomeNFTOmnibridge: require(`../../build/contracts/HomeNFTOmnibridge.json`),
   ForeignNFTOmnibridge: require(`../../build/contracts/ForeignNFTOmnibridge.json`),
   ERC721BridgeToken: require(`../../build/contracts/ERC721BridgeToken.json`),

--- a/flatten.sh
+++ b/flatten.sh
@@ -12,6 +12,7 @@ TOKEN_CONTRACTS_DIR=contracts/tokens
 
 echo "Flattening common bridge contracts"
 ${FLATTENER} contracts/upgradeability/EternalStorageProxy.sol > flats/EternalStorageProxy_flat.sol
+${FLATTENER} contracts/upgradeability/OwnedUpgradeabilityProxy.sol > flats/OwnedUpgradeabilityProxy_flat.sol
 
 echo "Flattening contracts related to NFT Omnibridge"
 ${FLATTENER} ${BRIDGE_CONTRACTS_DIR}/omnibridge_nft/HomeNFTOmnibridge.sol > flats/HomeNFTOmnibridge_flat.sol

--- a/test/omnibridge_nft/common.test.js
+++ b/test/omnibridge_nft/common.test.js
@@ -5,6 +5,7 @@ const AMBMock = artifacts.require('AMBMock')
 const ERC721BridgeToken = artifacts.require('ERC721BridgeToken')
 const NFTForwardingRulesManager = artifacts.require('NFTForwardingRulesManager')
 const SelectorTokenGasLimitManager = artifacts.require('SelectorTokenGasLimitManager')
+const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
 const selectors = {
   deployAndHandleBridgedNFT: '0x3c91b105',
   handleBridgedNFT: '0xfbc547ce',
@@ -277,7 +278,12 @@ function runTests(accounts, isHome) {
         describe('gas limit manager', () => {
           let manager
           beforeEach(async () => {
-            manager = await SelectorTokenGasLimitManager.new(ambBridgeContract.address, contract.address, 1000000)
+            const proxy = await OwnedUpgradeabilityProxy.new()
+            const impl = await SelectorTokenGasLimitManager.new()
+            const args = [ambBridgeContract.address, contract.address, 1000000]
+            const data = impl.contract.methods.initialize(...args).encodeABI()
+            await proxy.upgradeToAndCall(1, impl.address, data)
+            manager = await SelectorTokenGasLimitManager.at(proxy.address)
           })
 
           it('should allow to set new manager', async () => {
@@ -1100,7 +1106,11 @@ function runTests(accounts, isHome) {
       describe('oracle driven lane permissions', () => {
         let manager
         beforeEach(async () => {
-          manager = await NFTForwardingRulesManager.new(contract.address)
+          const proxy = await OwnedUpgradeabilityProxy.new()
+          const impl = await NFTForwardingRulesManager.new()
+          const data = impl.contract.methods.initialize(contract.address).encodeABI()
+          await proxy.upgradeToAndCall(1, impl.address, data)
+          manager = await NFTForwardingRulesManager.at(proxy.address)
           expect(await manager.mediator()).to.be.equal(contract.address)
         })
 


### PR DESCRIPTION
Closes #16 

The following steps were performed:
* replace module constructors with public `initialize()` method.
* update storage slots for `upgradeabilityOwner`/`version`/`implementation` used in proxy contracts in accordance to EIP1967. Using non-standard slots allows to use regular storage, without the need of eternal storage mappings.
* modules are now deployed as a sequence of 3 transactions:
  * deploy `OwnedUpgradeabilityProxy`
  * deploy module implementation contract
  * hook implementation to the storage contract and initialize module by using `upgradeToAndCall`