### PR TITLE
Bump version to 2.0.0-rc0

### DIFF
--- a/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
@@ -31,7 +31,7 @@ contract NFTOmnibridgeInfo is VersionableBridge {
             uint64 patch
         )
     {
-        return (1, 0, 0);
+        return (2, 0, 0);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge-nft",
-  "version": "1.0.0-rc1",
+  "version": "2.0.0-rc0",
   "description": "Omnibridge NFT AMB extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since the next release of the contracts contains changes which are not backward compatible with `1.0.0-rc0`, the major version is increased.