### PR TITLE
Sync audit-related changes from Omnibridge repo

### DIFF
--- a/contracts/upgradeable_contracts/Ownable.sol
+++ b/contracts/upgradeable_contracts/Ownable.sol
@@ -29,7 +29,8 @@ contract Ownable is EternalStorage {
      * @dev Throws if called through proxy by any account other than contract itself or an upgradeability owner.
      */
     modifier onlyRelevantSender() {
-        (bool isProxy, bytes memory returnData) = address(this).call(abi.encodeWithSelector(UPGRADEABILITY_OWNER));
+        (bool isProxy, bytes memory returnData) =
+            address(this).staticcall(abi.encodeWithSelector(UPGRADEABILITY_OWNER));
         require(
             !isProxy || // covers usage without calling through storage proxy
                 (returnData.length == 32 && msg.sender == abi.decode(returnData, (address))) || // covers usage through regular proxy calls

--- a/contracts/upgradeable_contracts/omnibridge_nft/components/common/FailedMessagesProcessor.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/common/FailedMessagesProcessor.sol
@@ -16,9 +16,10 @@ abstract contract FailedMessagesProcessor is BasicAMBMediator, BridgeOperationsS
      * @param _messageId id of the message which execution failed.
      */
     function requestFailedMessageFix(bytes32 _messageId) external {
-        require(!bridgeContract().messageCallStatus(_messageId));
-        require(bridgeContract().failedMessageReceiver(_messageId) == address(this));
-        require(bridgeContract().failedMessageSender(_messageId) == mediatorContractOnOtherSide());
+        IAMB bridge = bridgeContract();
+        require(!bridge.messageCallStatus(_messageId));
+        require(bridge.failedMessageReceiver(_messageId) == address(this));
+        require(bridge.failedMessageSender(_messageId) == mediatorContractOnOtherSide());
 
         bytes memory data = abi.encodeWithSelector(this.fixFailedMessage.selector, _messageId);
         _passMessage(data, false);

--- a/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
@@ -31,7 +31,7 @@ contract NFTOmnibridgeInfo is VersionableBridge {
             uint64 patch
         )
     {
-        return (2, 0, 0);
+        return (2, 0, 1);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge-nft",
-  "version": "2.0.0-rc0",
+  "version": "2.0.0-rc1",
   "description": "Omnibridge NFT AMB extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sync changes from the Omnibridge repo that are related to the code in this repository.
Closes #25 
The following changes were ported:
* https://github.com/poanetwork/omnibridge/pull/29
* https://github.com/poanetwork/omnibridge/pull/37
* https://github.com/poanetwork/omnibridge/pull/39
* https://github.com/poanetwork/omnibridge/pull/42
* https://github.com/poanetwork/omnibridge/pull/43